### PR TITLE
Add AMD RDNA4 GPUs

### DIFF
--- a/src/OllamaGPUCalculator.js
+++ b/src/OllamaGPUCalculator.js
@@ -49,6 +49,12 @@ const unsortedGpuSpecs = {
     'rx7900gre': { name: 'Radeon RX 7900 GRE', vram: 16, generation: 'RDNA3', tflops: 46, tdp: 260 },  // Correct: 260W
     'rx7800xt': { name: 'Radeon RX 7800 XT', vram: 16, generation: 'RDNA3', tflops: 37, tdp: 263 },  // Correct: 263W
     'rx7700xt': { name: 'Radeon RX 7700 XT', vram: 12, generation: 'RDNA3', tflops: 35, tdp: 245 },  // Correct: 245W
+	'rx9070xt': { name: 'Radeon RX 9070 XT', vram: 16, generation: 'RDNA4', tflops: 195, tdp: 304 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9070': { name: 'Radeon RX 9070', vram: 16, generation: 'RDNA4', tflops: 145, tdp: 220 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9060xt1': { name: 'Radeon RX 9060 XT', vram: 16, generation: 'RDNA4', tflops: 103, tdp: 160 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9060xt2': { name: 'Radeon RX 9060 XT', vram: 8, generation: 'RDNA4', tflops: 103, tdp: 150 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9060xt3': { name: 'Radeon RX 9060 XT LP', vram: 16, generation: 'RDNA4', tflops: 100, tdp: 140 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9060': { name: 'Radeon RX 9060', vram: 8, generation: 'RDNA4', tflops: 86, tdp: 132 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
 };
 
 const gpuSpecs = Object.fromEntries(

--- a/src/OllamaGPUCalculator.js
+++ b/src/OllamaGPUCalculator.js
@@ -50,11 +50,14 @@ const unsortedGpuSpecs = {
     'rx7800xt': { name: 'Radeon RX 7800 XT', vram: 16, generation: 'RDNA3', tflops: 37, tdp: 263 },  // Correct: 263W
     'rx7700xt': { name: 'Radeon RX 7700 XT', vram: 12, generation: 'RDNA3', tflops: 35, tdp: 245 },  // Correct: 245W
 	'rx9070xt': { name: 'Radeon RX 9070 XT', vram: 16, generation: 'RDNA4', tflops: 195, tdp: 304 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
-	'rx9070': { name: 'Radeon RX 9070', vram: 16, generation: 'RDNA4', tflops: 145, tdp: 220 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
-	'rx9060xt1': { name: 'Radeon RX 9060 XT', vram: 16, generation: 'RDNA4', tflops: 103, tdp: 160 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
-	'rx9060xt2': { name: 'Radeon RX 9060 XT', vram: 8, generation: 'RDNA4', tflops: 103, tdp: 150 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
-	'rx9060xt3': { name: 'Radeon RX 9060 XT LP', vram: 16, generation: 'RDNA4', tflops: 100, tdp: 140 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
-	'rx9060': { name: 'Radeon RX 9060', vram: 8, generation: 'RDNA4', tflops: 86, tdp: 132 },  // taken from AMD.com spec sheet, TFLOPS from peak half-precision (FP16 Matrix) performance
+	'rx9070': { name: 'Radeon RX 9070', vram: 16, generation: 'RDNA4', tflops: 145, tdp: 220 },  
+	'rx9060xt1': { name: 'Radeon RX 9060 XT', vram: 16, generation: 'RDNA4', tflops: 103, tdp: 160 },  
+	'rx9060xt2': { name: 'Radeon RX 9060 XT', vram: 8, generation: 'RDNA4', tflops: 103, tdp: 150 },  
+	'rx9060xt3': { name: 'Radeon RX 9060 XT LP', vram: 16, generation: 'RDNA4', tflops: 100, tdp: 140 },  
+	'rx9060': { name: 'Radeon RX 9060', vram: 8, generation: 'RDNA4', tflops: 86, tdp: 132 },  
+	'radaipro': { name: 'Radeon AI Pro R9700', vram: 32, generation: 'RDNA4', tflops: 191, tdp: 300 },  
+	'radaipros': { name: 'Radeon AI Pro R9700S', vram: 32, generation: 'RDNA4', tflops: 191, tdp: 300 },  // I might not be looking carefully enough, but... this + the GPU above seem basically identical 
+	'radaiprod': { name: 'Radeon AI Pro R9700D', vram: 32, generation: 'RDNA4', tflops: 99, tdp: 150 },
 };
 
 const gpuSpecs = Object.fromEntries(


### PR DESCRIPTION
This adds the consumer lineup of AMD's RDNA4 architecture:
1. 9060XT (8GB and 16GB variants)
2. 9060XT LP
3. 9070
4. 9070 XT

It also adds the workstation/enterprise RDNA4 GPUs (note it does NOT add the data-center scale GPUs/Accelerators:
1. Radeon AI Pro R9700
2. Radeon AI Pro R9700S
3. Radeon AI Pro R9700D

I may have missed one or two but I think this is the complete set.